### PR TITLE
fix(mailu): add missing HOST_AUTHSMTP variabl

### DIFF
--- a/charts/mailu/Chart.yaml
+++ b/charts/mailu/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.8"
 description: Mailu mail system fork with images working for AMD64+ARM64
 name: mailu
-version: 0.2.1
+version: 0.2.2
 icon: https://mailu.io/master/_images/logo.png

--- a/charts/mailu/README.md
+++ b/charts/mailu/README.md
@@ -1,6 +1,6 @@
 # mailu
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![AppVersion: 1.8](https://img.shields.io/badge/AppVersion-1.8-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![AppVersion: 1.8](https://img.shields.io/badge/AppVersion-1.8-informational?style=flat-square)
 
 Mailu mail system fork with images working for AMD64+ARM64
 

--- a/charts/mailu/templates/admin.yaml
+++ b/charts/mailu/templates/admin.yaml
@@ -80,6 +80,8 @@ spec:
             value: "{{ required "secretKey" .Values.secretKey }}"
           - name: AUTH_RATELIMIT
             value: "{{ required "mail.authRatelimit" .Values.mail.authRatelimit }}"
+          - name: HOST_AUTHSMTP
+            value: {{ include "mailu.fullname" . }}-postfix.{{ .Release.Namespace }}
           {{- if .Values.initialAccount }}
           - name: INITIAL_ADMIN_ACCOUNT
             value: {{ required "initialAccount.username" .Values.initialAccount.username }}


### PR DESCRIPTION
At the moment announcment page is failing because cannot get the address out of `HOST_AUTHSMTP`